### PR TITLE
update gem to current dev_support release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on: [pull_request]
+
+concurrency:
+  group: lint-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  ruby:
+    name: Check Ruby
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+      - name: Lint Ruby files
+        run: bundle exec rubocop -ESP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,71 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 4" # every Thursday
+
+concurrency:
+  group: test-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  rspec:
+    name: Solidus ${{ matrix.solidus-branch }}, Rails ${{ matrix.rails-version }} and Ruby ${{ matrix.ruby-version }} on ${{ matrix.database }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: true
+      matrix:
+        rails-version:
+          - "7.0"
+          - "7.1"
+          - "7.2"
+        ruby-version:
+          - "3.1"
+          - "3.4"
+        solidus-branch:
+          - "v4.1"
+          - "v4.2"
+          - "v4.3"
+          - "v4.4"
+          - "v4.5"
+        database:
+          - "postgresql"
+          - "mysql"
+          - "sqlite"
+        exclude:
+          - rails-version: "7.2"
+            solidus-branch: "v4.3"
+          - rails-version: "7.2"
+            solidus-branch: "v4.2"
+          - rails-version: "7.2"
+            solidus-branch: "v4.1"
+          - rails-version: "7.1"
+            solidus-branch: "v4.2"
+          - rails-version: "7.1"
+            solidus-branch: "v4.1"
+          - ruby-version: "3.4"
+            rails-version: "7.0"
+    env:
+      CODECOV_COVERAGE_PATH: ./coverage/coverage.xml
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run extension tests
+        uses: solidusio/test-solidus-extension@main
+        with:
+          database: ${{ matrix.database }}
+          rails-version: ${{ matrix.rails-version }}
+          ruby-version: ${{ matrix.ruby-version }}
+          solidus-branch: ${{ matrix.solidus-branch }}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.CODECOV_COVERAGE_PATH }}

--- a/Gemfile
+++ b/Gemfile
@@ -10,19 +10,13 @@ gem 'solidus', github: 'solidusio/solidus', branch: branch
 if branch >= 'v3.2'
   gem 'solidus_frontend'
 elsif branch == 'main'
-  gem 'solidus_frontend', github: 'solidusio/solidus_frontend', branch: branch
+  gem 'solidus_frontend', github: 'solidusio/solidus_frontend'
 else
   gem 'solidus_frontend', github: 'solidusio/solidus', branch: branch
 end
 
-# Needed to help Bundler figure out how to resolve dependencies,
-# otherwise it takes forever to resolve them.
-# See https://github.com/bundler/bundler/issues/6677
-gem 'rails', '>0.a'
-
-
-# Provides basic authentication functionality for testing parts of your engine
-gem 'solidus_auth_devise'
+rails_version = ENV.fetch('RAILS_VERSION', '7.0')
+gem 'rails', "~> #{rails_version}"
 
 case ENV.fetch('DB', nil)
 when 'mysql'
@@ -30,7 +24,16 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3'
+  gem 'sqlite3', rails_version < '7.2' ? '~> 1.4' : '~> 2.0'
+end
+
+if rails_version == '7.0'
+  gem 'concurrent-ruby', '< 1.3.5'
+end
+
+if RUBY_VERSION >= '3.4'
+  # Solidus Promotions uses CSV but does not have it as dependency yet.
+  gem 'csv'
 end
 
 # While we still support Ruby < 3 we need to workaround a limitation in
@@ -46,5 +49,3 @@ gemspec
 # We use `send` instead of calling `eval_gemfile` to work around an issue with
 # how Dependabot parses projects: https://github.com/dependabot/dependabot-core/issues/1658.
 send(:eval_gemfile, 'Gemfile-local') if File.exist? 'Gemfile-local'
-
-gem "solidus_admin", "~> 0.2.0"

--- a/app/models/solidus_cms/components_page.rb
+++ b/app/models/solidus_cms/components_page.rb
@@ -15,7 +15,7 @@ module SolidusCms
     delegate :name, to: :component, prefix: true
     delegate :backend_template, :frontend_template, :full_width?, to: :presenter
 
-    serialize :metadata, JsonSerializer
+    serialize :metadata, coder: JsonSerializer
 
     scope :active, -> { where active: true }
     scope :top_level, -> { where parent_id: nil }

--- a/app/models/solidus_cms/page.rb
+++ b/app/models/solidus_cms/page.rb
@@ -16,7 +16,7 @@ module SolidusCms
                                message: I18n.t('custom_pages.pages.slug_error') }
     scope :active, -> { where(active: true) }
 
-    serialize :metadata, JsonSerializer
+    serialize :metadata, coder: JsonSerializer
 
     def disabled?
       !active

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -30,7 +30,8 @@ echo "~~~> Removing the old sandbox"
 rm -rf ./sandbox
 
 echo "~~~> Creating a pristine Rails app"
-rails new sandbox \
+rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
+rails _${rails_version}_ new sandbox \
   --database="${DB:-sqlite3}" \
   --skip-git \
   --skip-keeps \
@@ -59,6 +60,14 @@ group :test, :development do
   end
 end
 RUBY
+
+echo "Generating manifest file"
+mkdir -p app/assets/config
+cat <<MANIFESTJS > app/assets/config/manifest.js
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+MANIFESTJS
 
 unbundled bundle install --gemfile Gemfile
 

--- a/lib/solidus_cms.rb
+++ b/lib/solidus_cms.rb
@@ -3,5 +3,3 @@
 require 'solidus_cms/configuration'
 require 'solidus_cms/version'
 require 'solidus_cms/engine'
-require "solidus_cms/json_serializer"
-require "solidus_cms/railtie" if defined?(Rails::Railtie)

--- a/lib/solidus_cms/engine.rb
+++ b/lib/solidus_cms/engine.rb
@@ -2,6 +2,8 @@
 
 require 'solidus_core'
 require 'solidus_support'
+require 'solidus_cms/json_serializer'
+require 'solidus_cms/railtie' if defined?(Rails::Railtie)
 
 module SolidusCms
   class Engine < Rails::Engine

--- a/solidus_cms.gemspec
+++ b/solidus_cms.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
-  spec.add_dependency 'solidus_support', '~> 0.5'
+  spec.add_dependency 'solidus_support', '>= 0.12.0'
 
-  spec.add_development_dependency 'solidus_dev_support', '~> 2.8'
+  spec.add_development_dependency 'solidus_dev_support', '~> 2.11'
 end


### PR DESCRIPTION
This update extension with last `solidus_dev_support`. Update include github actions config. I think we could use it at least until circle-ci be fixed. 

Also fixed serializer declaration that changed in latest rails versions

Test continue passing
![Screenshot from 2025-05-23 11-11-47](https://github.com/user-attachments/assets/88b14dd3-38e5-4d51-bd83-41ed7226cb32)